### PR TITLE
feat: auto-minimize large log properties and add destination output toggles

### DIFF
--- a/Sources/Huey/Huey.swift
+++ b/Sources/Huey/Huey.swift
@@ -8,13 +8,23 @@ public enum Log {
 
     public static var enableLogging = true
 
-    private static let defaultFileDestination = FileDestination()
+    private static let defaultFileDestination: FileDestination = {
+        let id = DestinationPreferences.identifier(for: FileDestination.self)
+        return FileDestination(
+            prettyPrint: DestinationPreferences.prettyPrint(for: id),
+            escapeStrings: DestinationPreferences.escapeStrings(for: id)
+        )
+    }()
 
     private static let destinationsLock = NSLock()
     private static var _destinations: [LogDestination] = {
         var list: [LogDestination] = [defaultFileDestination]
         #if DEBUG
-        list.append(SystemLogDestination())
+        let id = DestinationPreferences.identifier(for: SystemLogDestination.self)
+        list.append(SystemLogDestination(
+            prettyPrint: DestinationPreferences.prettyPrint(for: id),
+            escapeStrings: DestinationPreferences.escapeStrings(for: id)
+        ))
         #endif
         return list
     }()
@@ -31,7 +41,7 @@ public enum Log {
         _destinations.removeAll()
     }
 
-    private static func destinationsSnapshot() -> [LogDestination] {
+    public static func destinationsSnapshot() -> [LogDestination] {
         destinationsLock.lock()
         defer { destinationsLock.unlock() }
         return _destinations

--- a/Sources/Huey/Logging/FileDestination.swift
+++ b/Sources/Huey/Logging/FileDestination.swift
@@ -1,12 +1,14 @@
 import Foundation
 
-public final class FileDestination: LogDestination {
+public final class FileDestination: JSONFormattedLogDestination {
 
     public var minLevel: LogLevel
     public let directory: URL
     public let fileName: String
     public let maxFileSize: Int
     public let maxFileCount: Int
+    public var prettyPrint: Bool
+    public var escapeStrings: Bool
 
     private let queue = DispatchQueue(label: "com.huey.file-destination")
     private let fileManager = FileManager.default
@@ -21,13 +23,17 @@ public final class FileDestination: LogDestination {
         fileName: String = "huey.log",
         maxFileSize: Int = 5 * 1024 * 1024,
         maxFileCount: Int = 5,
-        minLevel: LogLevel = .verbose
+        minLevel: LogLevel = .verbose,
+        prettyPrint: Bool = false,
+        escapeStrings: Bool = true
     ) {
         self.directory = directory
         self.fileName = fileName
         self.maxFileSize = max(1, maxFileSize)
         self.maxFileCount = max(1, maxFileCount)
         self.minLevel = minLevel
+        self.prettyPrint = prettyPrint
+        self.escapeStrings = escapeStrings
     }
 
     public var activeFileURL: URL {
@@ -67,7 +73,7 @@ public final class FileDestination: LogDestination {
 
     public func send(_ event: LogEvent) {
         guard shouldSend(event) else { return }
-        guard let line = Self.encode(event) else { return }
+        guard let line = encode(event) else { return }
         queue.async { [weak self] in
             self?.write(line)
         }
@@ -139,7 +145,7 @@ public final class FileDestination: LogDestination {
         return (base, ext)
     }
 
-    static func encode(_ event: LogEvent) -> Data? {
+    func encode(_ event: LogEvent) -> Data? {
         var payload: [String: Any] = [
             "timestamp": event.timestamp.timeIntervalSince1970,
             "level": event.level.rawValue,
@@ -153,9 +159,13 @@ public final class FileDestination: LogDestination {
             payload["context"] = context
         }
         guard JSONSerialization.isValidJSONObject(payload),
-              var data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+              let raw = try? JSONSerialization.data(
+                withJSONObject: payload,
+                options: JSONFormatting.writingOptions(prettyPrint: prettyPrint)
+              ) else {
             return nil
         }
+        var data = JSONFormatting.postProcess(raw, escapeStrings: escapeStrings)
         data.append(0x0A) // newline
         return data
     }

--- a/Sources/Huey/Logging/LogDestination.swift
+++ b/Sources/Huey/Logging/LogDestination.swift
@@ -10,3 +10,54 @@ public extension LogDestination {
         event.level.rawValue >= minLevel.rawValue
     }
 }
+
+public protocol JSONFormattedLogDestination: LogDestination {
+    var prettyPrint: Bool { get set }
+    var escapeStrings: Bool { get set }
+}
+
+public enum DestinationPreferences {
+    public static func identifier(for type: Any.Type) -> String {
+        String(describing: type)
+    }
+
+    public static func identifier(for destination: LogDestination) -> String {
+        identifier(for: Swift.type(of: destination))
+    }
+
+    private static func prettyPrintKey(_ id: String) -> String { "huey.dest.\(id).prettyPrint" }
+    private static func escapeStringsKey(_ id: String) -> String { "huey.dest.\(id).escapeStrings" }
+
+    public static func prettyPrint(for id: String) -> Bool {
+        UserDefaults.standard.bool(forKey: prettyPrintKey(id))
+    }
+
+    public static func escapeStrings(for id: String) -> Bool {
+        if UserDefaults.standard.object(forKey: escapeStringsKey(id)) == nil { return true }
+        return UserDefaults.standard.bool(forKey: escapeStringsKey(id))
+    }
+
+    public static func setPrettyPrint(_ value: Bool, for id: String) {
+        UserDefaults.standard.set(value, forKey: prettyPrintKey(id))
+    }
+
+    public static func setEscapeStrings(_ value: Bool, for id: String) {
+        UserDefaults.standard.set(value, forKey: escapeStringsKey(id))
+    }
+}
+
+enum JSONFormatting {
+    static func writingOptions(prettyPrint: Bool) -> JSONSerialization.WritingOptions {
+        var opts: JSONSerialization.WritingOptions = [.sortedKeys]
+        if prettyPrint { opts.insert(.prettyPrinted) }
+        return opts
+    }
+
+    // JSONSerialization escapes `/` as `\/` and emits non-ASCII as UTF-8 bytes.
+    // Slash unescaping is the only meaningful knob; flip it when escapeStrings == false.
+    static func postProcess(_ data: Data, escapeStrings: Bool) -> Data {
+        guard !escapeStrings,
+              let s = String(data: data, encoding: .utf8) else { return data }
+        return Data(s.replacingOccurrences(of: "\\/", with: "/").utf8)
+    }
+}

--- a/Sources/Huey/Logging/SystemLogDestination.swift
+++ b/Sources/Huey/Logging/SystemLogDestination.swift
@@ -1,23 +1,29 @@
 import Foundation
 import os
 
-public final class SystemLogDestination: LogDestination {
+public final class SystemLogDestination: JSONFormattedLogDestination {
 
     public var minLevel: LogLevel
+    public var prettyPrint: Bool
+    public var escapeStrings: Bool
     private let logger: Logger
 
     public init(
         subsystem: String = Bundle.main.bundleIdentifier ?? "Huey",
         category: String = "Huey",
-        minLevel: LogLevel = .verbose
+        minLevel: LogLevel = .verbose,
+        prettyPrint: Bool = false,
+        escapeStrings: Bool = true
     ) {
         self.logger = Logger(subsystem: subsystem, category: category)
         self.minLevel = minLevel
+        self.prettyPrint = prettyPrint
+        self.escapeStrings = escapeStrings
     }
 
     public func send(_ event: LogEvent) {
         guard shouldSend(event) else { return }
-        let formatted = SystemLogDestination.format(event)
+        let formatted = format(event)
         switch event.level {
         case .verbose, .debug:
             logger.debug("\(formatted, privacy: .public)")
@@ -37,7 +43,7 @@ public final class SystemLogDestination: LogDestination {
         return f
     }()
 
-    static func format(_ event: LogEvent) -> String {
+    func format(_ event: LogEvent) -> String {
         let label: String
         switch event.level {
         case .verbose: label = "💜 VERBOSE"
@@ -47,12 +53,17 @@ public final class SystemLogDestination: LogDestination {
         case .error:   label = "🛑 ERROR"
         }
 
-        let timestamp = dateFormatter.string(from: event.timestamp)
+        let timestamp = SystemLogDestination.dateFormatter.string(from: event.timestamp)
         var line = "\(label): \(timestamp) [\(event.file).\(event.function):\(event.line)] \(event.message)"
         if let context = event.context, !context.isEmpty,
-           let data = try? JSONSerialization.data(withJSONObject: context, options: [.sortedKeys]),
-           let json = String(data: data, encoding: .utf8) {
-            line += " \(json)"
+           let raw = try? JSONSerialization.data(
+            withJSONObject: context,
+            options: JSONFormatting.writingOptions(prettyPrint: prettyPrint)
+           ) {
+            let processed = JSONFormatting.postProcess(raw, escapeStrings: escapeStrings)
+            if let json = String(data: processed, encoding: .utf8) {
+                line += " \(json)"
+            }
         }
         return line
     }

--- a/Sources/Huey/Views/DestinationsView.swift
+++ b/Sources/Huey/Views/DestinationsView.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+final class DestinationsVM: ObservableObject {
+
+    struct Row: Identifiable {
+        let id: ObjectIdentifier
+        let identifier: String
+        let title: String
+        let destination: JSONFormattedLogDestination
+    }
+
+    @Published var rows: [Row] = []
+
+    init() {
+        reload()
+    }
+
+    func reload() {
+        rows = Log.destinationsSnapshot().compactMap { dest in
+            guard let configurable = dest as? JSONFormattedLogDestination else { return nil }
+            let id = DestinationPreferences.identifier(for: dest)
+            return Row(
+                id: ObjectIdentifier(dest),
+                identifier: id,
+                title: id,
+                destination: configurable
+            )
+        }
+    }
+
+    func setPrettyPrint(_ value: Bool, for row: Row) {
+        row.destination.prettyPrint = value
+        DestinationPreferences.setPrettyPrint(value, for: row.identifier)
+        objectWillChange.send()
+    }
+
+    func setEscapeStrings(_ value: Bool, for row: Row) {
+        row.destination.escapeStrings = value
+        DestinationPreferences.setEscapeStrings(value, for: row.identifier)
+        objectWillChange.send()
+    }
+}
+
+struct DestinationsView: View {
+
+    @StateObject var viewModel = DestinationsVM()
+
+    var body: some View {
+        List {
+            ForEach(viewModel.rows) { row in
+                Section(header: Text(row.title)) {
+                    Toggle("Pretty print JSON", isOn: Binding(
+                        get: { row.destination.prettyPrint },
+                        set: { viewModel.setPrettyPrint($0, for: row) }
+                    ))
+                    Toggle("Escape strings", isOn: Binding(
+                        get: { row.destination.escapeStrings },
+                        set: { viewModel.setEscapeStrings($0, for: row) }
+                    ))
+                }
+            }
+        }
+    }
+}
+
+struct DestinationsView_Previews: PreviewProvider {
+    static var previews: some View {
+        DestinationsView()
+    }
+}

--- a/Sources/Huey/Views/LogDetailsView.swift
+++ b/Sources/Huey/Views/LogDetailsView.swift
@@ -35,9 +35,28 @@ struct LogDetailsView: View {
 struct ContextView: View {
     let key: String
     let value: AnyObject?
-    
-    @State var isExpanded = true
-    
+
+    private let rendered: String
+    @State private var isExpanded: Bool
+
+    init(key: String, value: AnyObject?) {
+        self.key = key
+        self.value = value
+        let rendered = String(describing: value)
+        self.rendered = rendered
+        _isExpanded = State(initialValue: !ContextView.isLarge(rendered))
+    }
+
+    private static func isLarge(_ rendered: String) -> Bool {
+        rendered.count > 200 || rendered.contains("\n")
+    }
+
+    private var preview: String {
+        let collapsed = rendered.replacingOccurrences(of: "\n", with: " ")
+        if collapsed.count <= 80 { return collapsed }
+        return String(collapsed.prefix(80)) + "…"
+    }
+
     var body: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 16) {
@@ -45,8 +64,14 @@ struct ContextView: View {
                     .bold()
                     .italic()
                 if isExpanded {
-                    Text(String(describing: value))
+                    Text(rendered)
                         .font(.system(size: 14, design: .monospaced))
+                } else {
+                    Text(preview)
+                        .font(.system(size: 14, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             }
         }

--- a/Sources/Huey/Views/LogsView.swift
+++ b/Sources/Huey/Views/LogsView.swift
@@ -10,15 +10,19 @@ import SwiftUI
 
 public struct LogsView: View {
     @StateObject var viewModel = LogsVM()
-    
+
     @State var showingFilter = false
-    
+    @State var showingDestinations = false
+
     public init() {}
-    
+
     public var body: some View {
         LogsListView(entries: viewModel.entries)
             .toolbar {
                 ToolbarItemGroup(placement: filterPlacement) {
+                    Button(action: { showingDestinations.toggle() }) {
+                        Image(systemName: "slider.horizontal.3")
+                    }
                     Button(action: { showingFilter.toggle() }) {
                         Image(systemName: "line.3.horizontal.decrease.circle")
                     }
@@ -26,6 +30,9 @@ public struct LogsView: View {
             }
             .sheet(isPresented: $showingFilter) {
                 FilterView()
+            }
+            .sheet(isPresented: $showingDestinations) {
+                DestinationsView()
             }
             .onAppear {
                 Task { await viewModel.load() }

--- a/Tests/HueyTests/DestinationFormattingTests.swift
+++ b/Tests/HueyTests/DestinationFormattingTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Huey
+
+final class DestinationFormattingTests: XCTestCase {
+
+    private func makeEvent(context: [String: String]? = nil) -> LogEvent {
+        LogEvent(
+            level: .info,
+            message: "hello",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            thread: "main",
+            file: "Source.swift",
+            function: "f()",
+            line: 1,
+            context: context
+        )
+    }
+
+    // MARK: FileDestination
+
+    func testFileDestinationDefaultsToCompactEscapedJSON() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let destination = FileDestination(directory: dir)
+        let data = try XCTUnwrap(destination.encode(makeEvent(context: ["path": "/Users/x"])))
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertFalse(text.contains("\n  "), "Compact JSON should not be indented")
+        XCTAssertTrue(text.contains("\\/Users\\/x"), "Default should escape forward slashes")
+    }
+
+    func testFileDestinationPrettyPrintsWhenEnabled() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let destination = FileDestination(directory: dir, prettyPrint: true)
+        let data = try XCTUnwrap(destination.encode(makeEvent()))
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("\n  "), "Pretty-printed JSON should contain indented lines")
+        XCTAssertTrue(text.hasSuffix("\n"), "JSON line must still terminate with a trailing newline")
+    }
+
+    func testFileDestinationUnescapesSlashesWhenEscapeStringsDisabled() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let destination = FileDestination(directory: dir, escapeStrings: false)
+        let data = try XCTUnwrap(destination.encode(makeEvent(context: ["path": "/Users/x/log.txt"])))
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(text.contains("/Users/x/log.txt"))
+        XCTAssertFalse(text.contains("\\/"))
+    }
+
+    // MARK: SystemLogDestination
+
+    func testSystemLogDestinationDefaultsToCompactEscapedContext() {
+        let destination = SystemLogDestination()
+        let line = destination.format(makeEvent(context: ["path": "/var/log"]))
+        XCTAssertTrue(line.contains("\\/var\\/log"))
+        XCTAssertFalse(line.contains("\n"))
+    }
+
+    func testSystemLogDestinationPrettyPrintsContextWhenEnabled() {
+        let destination = SystemLogDestination(prettyPrint: true)
+        let line = destination.format(makeEvent(context: ["a": "1", "b": "2"]))
+        XCTAssertTrue(line.contains("\n"), "Pretty-printed context should introduce newlines")
+    }
+
+    func testSystemLogDestinationUnescapesSlashesWhenEscapeStringsDisabled() {
+        let destination = SystemLogDestination(escapeStrings: false)
+        let line = destination.format(makeEvent(context: ["path": "/var/log"]))
+        XCTAssertTrue(line.contains("/var/log"))
+        XCTAssertFalse(line.contains("\\/"))
+    }
+
+    // MARK: DestinationPreferences
+
+    func testDestinationPreferencesEscapeStringsDefaultsTrueWhenUnset() {
+        let id = "huey.test.unset-\(UUID().uuidString)"
+        XCTAssertTrue(DestinationPreferences.escapeStrings(for: id))
+        XCTAssertFalse(DestinationPreferences.prettyPrint(for: id))
+    }
+
+    func testDestinationPreferencesRoundTrip() {
+        let id = "huey.test.roundtrip-\(UUID().uuidString)"
+        defer {
+            UserDefaults.standard.removeObject(forKey: "huey.dest.\(id).prettyPrint")
+            UserDefaults.standard.removeObject(forKey: "huey.dest.\(id).escapeStrings")
+        }
+        DestinationPreferences.setPrettyPrint(true, for: id)
+        DestinationPreferences.setEscapeStrings(false, for: id)
+        XCTAssertTrue(DestinationPreferences.prettyPrint(for: id))
+        XCTAssertFalse(DestinationPreferences.escapeStrings(for: id))
+    }
+}


### PR DESCRIPTION
## Summary
- `ContextView` in the log details screen now starts collapsed when the rendered value exceeds 200 chars or contains newlines, showing a single-line preview until tapped.
- New `JSONFormattedLogDestination` protocol adds `prettyPrint` and `escapeStrings` flags to `FileDestination` and `SystemLogDestination`, with a new `DestinationsView` toolbar entry for runtime toggling persisted to `UserDefaults`.
- Adds `DestinationFormattingTests` covering both flags on both destinations plus `DestinationPreferences` round-trip.

## Test plan
- [ ] `swift test` passes
- [ ] In the host app, log a large context payload and confirm the property auto-collapses with a preview
- [ ] Toggle "Pretty print JSON" on `FileDestination` and verify the active log file becomes multi-line
- [ ] Toggle "Escape strings" off on `SystemLogDestination` and verify Console.app shows `/` rather than `\/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)