### PR TITLE
fix: unwrap Optional from log property values in details view

### DIFF
--- a/Sources/Huey/Models/LogEntry.swift
+++ b/Sources/Huey/Models/LogEntry.swift
@@ -26,7 +26,7 @@ extension LogEntry {
                     thread: "main",
                     message: randomString(length: 13)
                 ),
-                context: ["json": ["what's up"]] as? [String: AnyObject]
+                context: ["json": "what's up"] as? [String: AnyObject]
             )
         }
     }

--- a/Sources/Huey/Views/LogDetailsView.swift
+++ b/Sources/Huey/Views/LogDetailsView.swift
@@ -42,7 +42,12 @@ struct ContextView: View {
     init(key: String, value: AnyObject?) {
         self.key = key
         self.value = value
-        let rendered = String(describing: value)
+        let rendered: String
+        if let value {
+            rendered = String(describing: value)
+        } else {
+            rendered = "nil"
+        }
         self.rendered = rendered
         _isExpanded = State(initialValue: !ContextView.isLarge(rendered))
     }


### PR DESCRIPTION
## Summary
- Render context property values in `LogDetailsView` without Swift's `Optional(...)` debug wrapper; show `nil` when the value is missing.
- Update preview sample data so a context value is a plain string instead of a single-element array.

## Test plan
- [ ] Open `LogDetailsView_Previews` and confirm string properties render as `hello` rather than `Optional("hello")`.
- [ ] Verify nil context values display as `nil`.