### PR TITLE
feat: make log detail properties copy-able

### DIFF
--- a/Sources/Huey/Views/LogDetailsView.swift
+++ b/Sources/Huey/Views/LogDetailsView.swift
@@ -7,6 +7,20 @@
 
 import Foundation
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+private func copyToPasteboard(_ string: String) {
+    #if canImport(UIKit)
+    UIPasteboard.general.string = string
+    #elseif canImport(AppKit)
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(string, forType: .string)
+    #endif
+}
 
 struct LogDetailsView: View {
     let entry: LogEntry
@@ -77,6 +91,14 @@ struct ContextView: View {
         }
         .onTapGesture {
             isExpanded.toggle()
+        }
+        .contextMenu {
+            Button("Copy Value") {
+                copyToPasteboard(rendered)
+            }
+            Button("Copy Key") {
+                copyToPasteboard(key)
+            }
         }
         .animation(.spring(), value: isExpanded)
     }


### PR DESCRIPTION
## Summary
- Add a context menu to each context property row in `LogDetailsView` with "Copy Value" and "Copy Key" actions.
- New cross-platform `copyToPasteboard` helper uses `UIPasteboard` on iOS and `NSPasteboard` on macOS so the same call site works on both targets.
- Existing tap-to-expand behavior is preserved.

## Test plan
- [ ] macOS: right-click a property → "Copy Value" / "Copy Key" copy the expected text.
- [ ] iOS: long-press a property → same check.
- [ ] Verify "Copy Value" copies the full rendered string (not the 80-char preview) for a large/multi-line property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)